### PR TITLE
feat: add identify empty slices

### DIFF
--- a/goption.go
+++ b/goption.go
@@ -32,7 +32,7 @@ func (c Optional[T]) Get() (T, error) {
 	return c.value, nil
 }
 
-// IsPresent returns true if there is a value present, otherwise false.
+// IsPresent returns true if there is a value present, otherwise false. It recognizes an empty slice as not present so it returns false
 func (c Optional[T]) IsPresent() bool {
 	return c.isValidValue
 }

--- a/goption.go
+++ b/goption.go
@@ -69,8 +69,13 @@ func isValidData[T any](value T) bool {
 	}
 	kind := typeOfValue.Kind()
 	val := reflect.ValueOf(value)
-	if kind == reflect.Pointer {
+
+	switch kind {
+	case reflect.Pointer:
 		return !val.IsNil()
+	case reflect.Slice:
+		return val.Len() != 0
+	default:
+		return !val.IsZero()
 	}
-	return !val.IsZero()
 }

--- a/goption_test.go
+++ b/goption_test.go
@@ -74,6 +74,8 @@ var _ = Describe("Goption", func() {
 			Entry("empty int", int(0), false),
 			Entry("filled int", int(1), true),
 			Entry("empty optional", goption.Optional[string]{}, false),
+			Entry("empty slice", []string{}, false),
+			Entry("empty slice of pointers", []*string{}, false),
 		)
 	})
 


### PR DESCRIPTION
There was a missing case. What happen when a slice is present but it is empty? This PR solve this identifying when a slice is empty or it is not.

So, calling IsPresent method in case a slice is empty returns false, otherwise true