### PR TITLE
fix: recognize empty from unmarshall

### DIFF
--- a/goption.go
+++ b/goption.go
@@ -21,8 +21,7 @@ func Empty[T any]() Optional[T] {
 
 // Of returns an Optional with the specified present value. It does not matters if value is nil
 func Of[T any](value T) Optional[T] {
-	_, isValid := isValidData(value)
-	return Optional[T]{value: value, isValidValue: isValid}
+	return Optional[T]{value: value, isValidValue: getIsValidDataBool(value)}
 }
 
 // Get when a value is present returns the value, otherwise throws ErrNoSuchElement.
@@ -79,4 +78,9 @@ func isValidData[T any](value T) (reflect.Value, bool) {
 	default:
 		return val, !val.IsZero()
 	}
+}
+
+func getIsValidDataBool[T any](value T) bool {
+	_, is := isValidData(value)
+	return is
 }

--- a/json.go
+++ b/json.go
@@ -3,15 +3,19 @@ package goption
 import (
 	"encoding/json"
 	"reflect"
+	"strconv"
 )
 
 func (c *Optional[T]) UnmarshalJSON(data []byte) error {
-	asString := string(data)
-	if asString == `"null"` || asString == `""` {
-		c.isValidValue = false
-		return nil
+	unquoted, err := strconv.Unquote(string(data))
+	if err != nil {
+		return err
 	}
-	c.isValidValue = len(data) > 0
+	if unquoted == "null" {
+		unquoted = ""
+	}
+	_, isValid := isValidData(unquoted)
+	c.isValidValue = isValid
 	if err := json.Unmarshal(data, &c.value); err != nil {
 		return err
 	}

--- a/json.go
+++ b/json.go
@@ -6,7 +6,8 @@ import (
 )
 
 func (c *Optional[T]) UnmarshalJSON(data []byte) error {
-	if string(data) == `"null"` {
+	asString := string(data)
+	if asString == `"null"` || asString == `""` {
 		c.isValidValue = false
 		return nil
 	}

--- a/json.go
+++ b/json.go
@@ -14,8 +14,7 @@ func (c *Optional[T]) UnmarshalJSON(data []byte) error {
 	if unquoted == "null" {
 		unquoted = ""
 	}
-	_, isValid := isValidData(unquoted)
-	c.isValidValue = isValid
+	c.isValidValue = getIsValidDataBool(unquoted)
 	if err := json.Unmarshal(data, &c.value); err != nil {
 		return err
 	}

--- a/json_test.go
+++ b/json_test.go
@@ -46,6 +46,19 @@ var _ = Describe("Json", func() {
 				Expect(holder.IsPresent()).To(BeFalse())
 			})
 		})
+
+		When("is zero", func() {
+			It("creates an empty optional", func() {
+				var (
+					jsonData = []byte(`""`)
+					holder   = goption.Empty[string]()
+				)
+				err := holder.UnmarshalJSON(jsonData)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(holder.IsPresent()).To(BeFalse())
+			})
+		})
 	})
 
 	Describe("MarshalJson", func() {


### PR DESCRIPTION
UnmarshallJSON does not identify if a value was empty, just if value was null. This is changed using isValidData method and handling null case on Unmarshall method