### PR TITLE
fix: add handling multiline's strings to be unmarshal

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -20,10 +20,9 @@ var _ = Describe("Json", func() {
 
 	Describe("UnmarshalJSON", func() {
 
-		It("generates optional from json string", func() {
+		DescribeTable("generates optional from json string", func(expectedNameData string) {
 			var (
-				expectedNameData = "a name"
-				jsonData         = []byte(fmt.Sprintf(
+				jsonData = []byte(fmt.Sprintf(
 					`"%v"`,
 					expectedNameData,
 				))
@@ -33,7 +32,14 @@ var _ = Describe("Json", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(holder.Get()).To(Equal(expectedNameData))
-		})
+		},
+			Entry("one line string", "a name"),
+			Entry("multiline strings", `a name
+a name
+a name
+
+a name`),
+		)
 
 		When("is as null", func() {
 			DescribeTable("creates an empty optional", func(jsonData []byte) {


### PR DESCRIPTION
I noticed when you try to unmarshal multiline strings this causes an error. This PR solves this problem