### PR TITLE
fix: add handling multiline's strings \r carriage return

### DIFF
--- a/json.go
+++ b/json.go
@@ -13,13 +13,17 @@ func (c *Optional[T]) UnmarshalJSON(data []byte) error {
 		valuer struct {
 			Value string `json:"value"`
 		}
-		asJsonString = strings.ReplaceAll(
+	)
+	asJsonString := strings.ReplaceAll(
+		strings.ReplaceAll(
 			fmt.Sprintf(`{"value": %s}`, data),
 			"\n",
 			"\\n",
-		)
-		asJsonBytes = []byte(asJsonString)
+		),
+		"\r",
+		"\\r",
 	)
+	asJsonBytes := []byte(asJsonString)
 
 	if err := json.Unmarshal(asJsonBytes, &valuer); err != nil {
 		return err

--- a/json_test.go
+++ b/json_test.go
@@ -39,6 +39,7 @@ a name
 a name
 
 a name`),
+			Entry("multiline strings with carriage return", "\r\na name\r\n"),
 		)
 
 		When("is as null", func() {


### PR DESCRIPTION
I forgot \r to be avoided