### PR TITLE
fix: check type implement sql scan

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -54,9 +54,15 @@ func (c *Optional[T]) Scan(src any) error {
 	return fmt.Errorf("interface conversion: interface {} is %s, not %s nor implements sql.Scanner", srcValue.Type(), destType)
 }
 
+// Value returns a driver Value.
+// Value must not panic.
 func (c Optional[T]) Value() (driver.Value, error) {
 	if !c.isValidValue {
 		return nil, nil
+	}
+
+	if asValuer, ok := interface{}(&c.value).(driver.Valuer); ok {
+		return asValuer.Value()
 	}
 	return c.value, nil
 

--- a/sql.go
+++ b/sql.go
@@ -1,6 +1,7 @@
 package goption
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"fmt"
 	"reflect"
@@ -27,16 +28,30 @@ import (
 func (c *Optional[T]) Scan(src any) error {
 	srcValue, isSrcValid := isValidData(src)
 	c.isValidValue = isSrcValid
-	if isSrcValid {
-		destType := reflect.TypeOf(c.value)
-		if !srcValue.Type().ConvertibleTo(destType) {
-			return fmt.Errorf("interface conversion: interface {} is %s, not %s", srcValue.Type(), destType)
-		}
+	if !isSrcValid {
+		return nil
+	}
 
+	destType := reflect.TypeOf(c.value)
+	if srcValue.Type().ConvertibleTo(destType) {
 		c.value = srcValue.Convert(destType).Interface().(T)
 		return nil
 	}
-	return nil
+
+	destTypeP := reflect.TypeOf(&c.value)
+	scannerType := reflect.TypeOf((*sql.Scanner)(nil))
+	if destTypeP.Implements(scannerType.Elem()) {
+		var s T
+		if asScanner, ok := interface{}(&s).(sql.Scanner); ok {
+			if err := asScanner.Scan(src); err != nil {
+				return err
+			}
+			c.value = s
+			return nil
+		}
+	}
+
+	return fmt.Errorf("interface conversion: interface {} is %s, not %s nor implements sql.Scanner", srcValue.Type(), destType)
 }
 
 func (c Optional[T]) Value() (driver.Value, error) {

--- a/sql_test.go
+++ b/sql_test.go
@@ -20,6 +20,15 @@ type Activity struct {
 	Description goption.Optional[string]    `json:"description"`
 }
 
+type WithScan struct {
+	data int
+}
+
+func (c *WithScan) Scan(src any) error {
+	c.data = src.(int)
+	return nil
+}
+
 var _ = Describe("Sql", func() {
 
 	It("works on db", Label("Integration"), func() {
@@ -142,6 +151,16 @@ var _ = Describe("Sql", func() {
 
 				Expect(opt.Scan(400)).To(Succeed())
 				Expect(opt.IsPresent()).To(BeTrue())
+			})
+		})
+
+		When("data implements its own scan method", func() {
+			It("calls it to do transform", func() {
+				opt := goption.Empty[WithScan]()
+
+				Expect(opt.Scan(400)).To(Succeed())
+				Expect(opt.IsPresent()).To(BeTrue())
+				Expect(opt.MustGet().data).To(Equal(400))
 			})
 		})
 	})

--- a/sql_test.go
+++ b/sql_test.go
@@ -2,6 +2,7 @@ package goption_test
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"log"
 	"os"
@@ -27,6 +28,10 @@ type WithScan struct {
 func (c *WithScan) Scan(src any) error {
 	c.data = src.(int)
 	return nil
+}
+
+func (c WithScan) Value() (driver.Value, error) {
+	return c.data, nil
 }
 
 var _ = Describe("Sql", func() {
@@ -185,6 +190,17 @@ var _ = Describe("Sql", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(got).ToNot(BeNil())
+			})
+		})
+
+		When("data implements its own value method", func() {
+			It("calls it to do transform", func() {
+				var opt = goption.Of(WithScan{data: 300})
+
+				got, err := opt.Value()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got.(int)).To(Equal(opt.MustGet().data))
 			})
 		})
 	})


### PR DESCRIPTION
sql.Scanner and driver.Valuer are now implemented. This allows struct types which implements these interfaces are handled