### PR TITLE
feat: add IsZero method for Go 1.24 omitzero support, related to issue #23

### DIFF
--- a/goption.go
+++ b/goption.go
@@ -62,6 +62,16 @@ func (c Optional[T]) MustGet() T {
 	return val
 }
 
+// IsZero returns true if the Optional is empty or contains a zero value.
+// This method is used by the encoding/json package to determine if a field should be omitted.
+func (c Optional[T]) IsZero() bool {
+	if !c.isValidValue {
+		return true
+	}
+	val, is := isValidData(c.value)
+	return !is || val.IsZero()
+}
+
 func isValidData[T any](value T) (reflect.Value, bool) {
 	typeOfValue := reflect.TypeOf(value)
 	if typeOfValue == nil {

--- a/goption_test.go
+++ b/goption_test.go
@@ -188,3 +188,37 @@ var _ = Describe("Goption", func() {
 	})
 
 })
+
+var _ = Describe("IsZero", func() {
+	It("should return true for empty optional", func() {
+		Expect(goption.Empty[any]().IsZero()).To(BeTrue())
+	})
+
+	It("should return true for optional with nil", func() {
+		Expect(goption.Of[any](nil).IsZero()).To(BeTrue())
+	})
+
+	It("should return true for optional with zero string", func() {
+		Expect(goption.Of[string]("").IsZero()).To(BeTrue())
+	})
+
+	It("should return true for optional with zero int", func() {
+		Expect(goption.Of[int](0).IsZero()).To(BeTrue())
+	})
+
+	It("should return false for optional with non-zero string", func() {
+		Expect(goption.Of[string]("hello").IsZero()).To(BeFalse())
+	})
+
+	It("should return false for optional with non-zero int", func() {
+		Expect(goption.Of[int](42).IsZero()).To(BeFalse())
+	})
+
+	It("should return true for optional with empty slice", func() {
+		Expect(goption.Of[[]int]([]int{}).IsZero()).To(BeTrue())
+	})
+
+	It("should return false for optional with non-empty slice", func() {
+		Expect(goption.Of[[]int]([]int{1, 2, 3}).IsZero()).To(BeFalse())
+	})
+})


### PR DESCRIPTION
This PR adds a new IsZero() method to the Optional[T] type to support the new omitzero behavior introduced in Go 1.24.

Basically, IsZero() will return true if the Optional is either empty or holding a zero value — like nil, 0, an empty string, or an empty slice. This makes it easier to skip over these fields when encoding to JSON.

It uses reflection to handle all the different types properly. Should help keep your JSON output nice and clean.

This is related to the issue #23 